### PR TITLE
Fixed __time_delay and changing all time functions with this implementation

### DIFF
--- a/library/GNUMakefile.os4
+++ b/library/GNUMakefile.os4
@@ -65,7 +65,7 @@ WARNINGS := \
 
 INCLUDES   := -Iinclude -I. -I$(SDK_INCLUDE)
 #WARNINGS   := -Werror -Wno-cast-function-type -Wno-array-bounds -Wno-unused-value 
- OPTIONS   := -DUSE_64_BIT_INTS -D__USE_INLINE__ -D__CLIB2__ -Wa,-mregnames -fno-builtin -fno-common $(WARNINGS) -DUNIX_PATH_SEMANTICS -Wno-error=array-bounds -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-parameter -std=c99 -nostdlib
+ OPTIONS   := -DUSE_64_BIT_INTS -D__USE_INLINE__ -D__CLIB2__ -D_GNU_SOURCE -Wa,-mregnames -fno-builtin -fno-common $(WARNINGS) -DUNIX_PATH_SEMANTICS -Wno-error=array-bounds -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-parameter -std=c99 -nostdlib
 OPTIMIZE   := -DNDEBUG -O3 -fno-inline
 
 DEBUG     := -ggdb

--- a/library/amiga_dotimer.c
+++ b/library/amiga_dotimer.c
@@ -60,79 +60,77 @@
 
 #if defined(__NEW_TIMEVAL_DEFINITION_USED__)
 
-#define timeval		TimeVal
-#define tv_secs		Seconds
-#define tv_micro	Microseconds
+#define timeval TimeVal
+#define tv_secs Seconds
+#define tv_micro Microseconds
 
-#define timerequest	TimeRequest
-#define tr_node		Request
-#define tr_time		Time
+#define timerequest TimeRequest
+#define tr_node Request
+#define tr_time Time
 
 #endif /* __NEW_TIMEVAL_DEFINITION_USED__ */
 
 /****************************************************************************/
 
-LONG
-DoTimer(struct timeval *tv,LONG unit,LONG command)
+LONG DoTimer(struct timeval *tv, LONG unit, LONG command)
 {
-	struct TimeRequest * tr = NULL;
-	struct MsgPort * mp;
+	struct TimeRequest *tr = NULL;
+	struct MsgPort *mp;
 	LONG error;
 
 	PROFILE_OFF();
 
-	assert( tv != NULL );
+	assert(tv != NULL);
 
 	mp = AllocSysObjectTags(ASOT_PORT,
-		ASOPORT_Action,		PA_SIGNAL,
-		ASOPORT_AllocSig,	FALSE,
-		ASOPORT_Signal,		SIGB_SINGLE,
-		ASOPORT_Target,		FindTask(NULL),
-	TAG_DONE);
+							ASOPORT_Action, PA_SIGNAL,
+							ASOPORT_AllocSig, FALSE,
+							ASOPORT_Signal, SIGB_SINGLE,
+							ASOPORT_Target, FindTask(NULL),
+							TAG_DONE);
 
-	if(mp == NULL)
+	if (mp == NULL)
 	{
 		error = IOERR_OPENFAIL;
 		goto out;
 	}
-
 
 	tr = AllocSysObjectTags(ASOT_IOREQUEST, ASOIOR_Size, sizeof(struct TimeRequest), ASOIOR_ReplyPort, mp, TAG_END);
-	if(tr == NULL)
+	if (tr == NULL)
 	{
 		error = IOERR_OPENFAIL;
 		goto out;
 	}
 
-	error = OpenDevice(TIMERNAME,(ULONG)unit,(struct IORequest *)tr,0);
-	if(error != 0)
+	error = OpenDevice(TIMERNAME, (ULONG)unit, (struct IORequest *)tr, 0);
+	if (error != 0)
 		goto out;
 
-	tr->tr_node.io_Command	= command;
-	tr->tr_time.tv_secs		= tv->tv_secs;
-	tr->tr_time.tv_micro	= tv->tv_micro;
+	tr->tr_node.io_Command = command;
+	tr->tr_time.tv_secs = tv->tv_secs;
+	tr->tr_time.tv_micro = tv->tv_micro;
 
-	SetSignal(0,(1UL << mp->mp_SigBit));
+	SetSignal(0, (1UL << mp->mp_SigBit));
 
 	error = DoIO((struct IORequest *)tr);
 
-	tv->tv_secs		= tr->tr_time.tv_secs;
-	tv->tv_micro	= tr->tr_time.tv_micro;
+	tv->tv_secs = tr->tr_time.tv_secs;
+	tv->tv_micro = tr->tr_time.tv_micro;
 
- out:
+out:
 
-	if(tr != NULL)
+	if (tr != NULL)
 	{
-		if(tr->tr_node.io_Device != NULL)
+		if (tr->tr_node.io_Device != NULL)
 			CloseDevice((struct IORequest *)tr);
 
 		FreeSysObject(ASOT_IOREQUEST, tr);
 	}
 
-	if(mp != NULL)
-		FreeSysObject(ASOT_PORT,mp);
+	if (mp != NULL)
+		FreeSysObject(ASOT_PORT, mp);
 
 	PROFILE_ON();
 
-	return(error);
+	return (error);
 }

--- a/library/include/features.h
+++ b/library/include/features.h
@@ -1,0 +1,439 @@
+/* Copyright (C) 1991-2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef	_FEATURES_H
+#define	_FEATURES_H	1
+
+/* These are defined by the user (or the compiler)
+   to specify the desired environment:
+
+   __STRICT_ANSI__	ISO Standard C.
+   _ISOC99_SOURCE	Extensions to ISO C89 from ISO C99.
+   _ISOC11_SOURCE	Extensions to ISO C99 from ISO C11.
+   __STDC_WANT_LIB_EXT2__
+			Extensions to ISO C99 from TR 27431-2:2010.
+   __STDC_WANT_IEC_60559_BFP_EXT__
+			Extensions to ISO C11 from TS 18661-1:2014.
+   __STDC_WANT_IEC_60559_FUNCS_EXT__
+			Extensions to ISO C11 from TS 18661-4:2015.
+   __STDC_WANT_IEC_60559_TYPES_EXT__
+			Extensions to ISO C11 from TS 18661-3:2015.
+
+   _POSIX_SOURCE	IEEE Std 1003.1.
+   _POSIX_C_SOURCE	If ==1, like _POSIX_SOURCE; if >=2 add IEEE Std 1003.2;
+			if >=199309L, add IEEE Std 1003.1b-1993;
+			if >=199506L, add IEEE Std 1003.1c-1995;
+			if >=200112L, all of IEEE 1003.1-2004
+			if >=200809L, all of IEEE 1003.1-2008
+   _XOPEN_SOURCE	Includes POSIX and XPG things.  Set to 500 if
+			Single Unix conformance is wanted, to 600 for the
+			sixth revision, to 700 for the seventh revision.
+   _XOPEN_SOURCE_EXTENDED XPG things and X/Open Unix extensions.
+   _LARGEFILE_SOURCE	Some more functions for correct standard I/O.
+   _LARGEFILE64_SOURCE	Additional functionality from LFS for large files.
+   _FILE_OFFSET_BITS=N	Select default filesystem interface.
+   _ATFILE_SOURCE	Additional *at interfaces.
+   _GNU_SOURCE		All of the above, plus GNU extensions.
+   _DEFAULT_SOURCE	The default set of features (taking precedence over
+			__STRICT_ANSI__).
+
+   _FORTIFY_SOURCE	Add security hardening to many library functions.
+			Set to 1 or 2; 2 performs stricter checks than 1.
+
+   _REENTRANT, _THREAD_SAFE
+			Obsolete; equivalent to _POSIX_C_SOURCE=199506L.
+
+   The `-ansi' switch to the GNU C compiler, and standards conformance
+   options such as `-std=c99', define __STRICT_ANSI__.  If none of
+   these are defined, or if _DEFAULT_SOURCE is defined, the default is
+   to have _POSIX_SOURCE set to one and _POSIX_C_SOURCE set to
+   200809L, as well as enabling miscellaneous functions from BSD and
+   SVID.  If more than one of these are defined, they accumulate.  For
+   example __STRICT_ANSI__, _POSIX_SOURCE and _POSIX_C_SOURCE together
+   give you ISO C, 1003.1, and 1003.2, but nothing else.
+
+   These are defined by this file and are used by the
+   header files to decide what to declare or define:
+
+   __GLIBC_USE (F)	Define things from feature set F.  This is defined
+			to 1 or 0; the subsequent macros are either defined
+			or undefined, and those tests should be moved to
+			__GLIBC_USE.
+   __USE_ISOC11		Define ISO C11 things.
+   __USE_ISOC99		Define ISO C99 things.
+   __USE_ISOC95		Define ISO C90 AMD1 (C95) things.
+   __USE_ISOCXX11	Define ISO C++11 things.
+   __USE_POSIX		Define IEEE Std 1003.1 things.
+   __USE_POSIX2		Define IEEE Std 1003.2 things.
+   __USE_POSIX199309	Define IEEE Std 1003.1, and .1b things.
+   __USE_POSIX199506	Define IEEE Std 1003.1, .1b, .1c and .1i things.
+   __USE_XOPEN		Define XPG things.
+   __USE_XOPEN_EXTENDED	Define X/Open Unix things.
+   __USE_UNIX98		Define Single Unix V2 things.
+   __USE_XOPEN2K        Define XPG6 things.
+   __USE_XOPEN2KXSI     Define XPG6 XSI things.
+   __USE_XOPEN2K8       Define XPG7 things.
+   __USE_XOPEN2K8XSI    Define XPG7 XSI things.
+   __USE_LARGEFILE	Define correct standard I/O things.
+   __USE_LARGEFILE64	Define LFS things with separate names.
+   __USE_FILE_OFFSET64	Define 64bit interface as default.
+   __USE_MISC		Define things from 4.3BSD or System V Unix.
+   __USE_ATFILE		Define *at interfaces and AT_* constants for them.
+   __USE_GNU		Define GNU extensions.
+   __USE_FORTIFY_LEVEL	Additional security measures used, according to level.
+
+   The macros `__GNU_LIBRARY__', `__GLIBC__', and `__GLIBC_MINOR__' are
+   defined by this file unconditionally.  `__GNU_LIBRARY__' is provided
+   only for compatibility.  All new code should use the other symbols
+   to test for features.
+
+   All macros listed above as possibly being defined by this file are
+   explicitly undefined if they are not explicitly defined.
+   Feature-test macros that are not defined by the user or compiler
+   but are implied by the other feature-test macros defined (or by the
+   lack of any definitions) are defined by the file.
+
+   ISO C feature test macros depend on the definition of the macro
+   when an affected header is included, not when the first system
+   header is included, and so they are handled in
+   <bits/libc-header-start.h>, which does not have a multiple include
+   guard.  Feature test macros that can be handled from the first
+   system header included are handled here.  */
+
+
+/* Undefine everything, so we get a clean slate.  */
+#undef	__USE_ISOC11
+#undef	__USE_ISOC99
+#undef	__USE_ISOC95
+#undef	__USE_ISOCXX11
+#undef	__USE_POSIX
+#undef	__USE_POSIX2
+#undef	__USE_POSIX199309
+#undef	__USE_POSIX199506
+#undef	__USE_XOPEN
+#undef	__USE_XOPEN_EXTENDED
+#undef	__USE_UNIX98
+#undef	__USE_XOPEN2K
+#undef	__USE_XOPEN2KXSI
+#undef	__USE_XOPEN2K8
+#undef	__USE_XOPEN2K8XSI
+#undef	__USE_LARGEFILE
+#undef	__USE_LARGEFILE64
+#undef	__USE_FILE_OFFSET64
+#undef	__USE_MISC
+#undef	__USE_ATFILE
+#undef	__USE_GNU
+#undef	__USE_FORTIFY_LEVEL
+#undef	__KERNEL_STRICT_NAMES
+#undef	__GLIBC_USE_DEPRECATED_GETS
+
+/* Suppress kernel-name space pollution unless user expressedly asks
+   for it.  */
+#ifndef _LOOSE_KERNEL_NAMES
+# define __KERNEL_STRICT_NAMES
+#endif
+
+/* Convenience macro to test the version of gcc.
+   Use like this:
+   #if __GNUC_PREREQ (2,8)
+   ... code requiring gcc 2.8 or later ...
+   #endif
+   Note: only works for GCC 2.0 and later, because __GNUC_MINOR__ was
+   added in 2.0.  */
+#if defined __GNUC__ && defined __GNUC_MINOR__
+# define __GNUC_PREREQ(maj, min) \
+	((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+#else
+# define __GNUC_PREREQ(maj, min) 0
+#endif
+
+/* Similarly for clang.  Features added to GCC after version 4.2 may
+   or may not also be available in clang, and clang's definitions of
+   __GNUC(_MINOR)__ are fixed at 4 and 2 respectively.  Not all such
+   features can be queried via __has_extension/__has_feature.  */
+#if defined __clang_major__ && defined __clang_minor__
+# define __glibc_clang_prereq(maj, min) \
+  ((__clang_major__ << 16) + __clang_minor__ >= ((maj) << 16) + (min))
+#else
+# define __glibc_clang_prereq(maj, min) 0
+#endif
+
+/* Whether to use feature set F.  */
+#define __GLIBC_USE(F)	__GLIBC_USE_ ## F
+
+/* _BSD_SOURCE and _SVID_SOURCE are deprecated aliases for
+   _DEFAULT_SOURCE.  If _DEFAULT_SOURCE is present we do not
+   issue a warning; the expectation is that the source is being
+   transitioned to use the new macro.  */
+#if (defined _BSD_SOURCE || defined _SVID_SOURCE) \
+    && !defined _DEFAULT_SOURCE
+# warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
+# undef  _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE	1
+#endif
+
+/* If _GNU_SOURCE was defined by the user, turn on all the other features.  */
+#ifdef _GNU_SOURCE
+# undef  _ISOC95_SOURCE
+# define _ISOC95_SOURCE	1
+# undef  _ISOC99_SOURCE
+# define _ISOC99_SOURCE	1
+# undef  _ISOC11_SOURCE
+# define _ISOC11_SOURCE	1
+# undef  _POSIX_SOURCE
+# define _POSIX_SOURCE	1
+# undef  _POSIX_C_SOURCE
+# define _POSIX_C_SOURCE	200809L
+# undef  _XOPEN_SOURCE
+# define _XOPEN_SOURCE	700
+# undef  _XOPEN_SOURCE_EXTENDED
+# define _XOPEN_SOURCE_EXTENDED	1
+# undef	 _LARGEFILE64_SOURCE
+# define _LARGEFILE64_SOURCE	1
+# undef  _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE	1
+# undef  _ATFILE_SOURCE
+# define _ATFILE_SOURCE	1
+#endif
+
+/* If nothing (other than _GNU_SOURCE and _DEFAULT_SOURCE) is defined,
+   define _DEFAULT_SOURCE.  */
+#if (defined _DEFAULT_SOURCE					\
+     || (!defined __STRICT_ANSI__				\
+	 && !defined _ISOC99_SOURCE				\
+	 && !defined _POSIX_SOURCE && !defined _POSIX_C_SOURCE	\
+	 && !defined _XOPEN_SOURCE))
+# undef  _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE	1
+#endif
+
+/* This is to enable the ISO C11 extension.  */
+#if (defined _ISOC11_SOURCE \
+     || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L))
+# define __USE_ISOC11	1
+#endif
+
+/* This is to enable the ISO C99 extension.  */
+#if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \
+     || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L))
+# define __USE_ISOC99	1
+#endif
+
+/* This is to enable the ISO C90 Amendment 1:1995 extension.  */
+#if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \
+     || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199409L))
+# define __USE_ISOC95	1
+#endif
+
+#ifdef __cplusplus
+/* This is to enable compatibility for ISO C++17.  */
+# if __cplusplus >= 201703L
+#  define __USE_ISOC11	1
+# endif
+/* This is to enable compatibility for ISO C++11.
+   Check the temporary macro for now, too.  */
+# if __cplusplus >= 201103L || defined __GXX_EXPERIMENTAL_CXX0X__
+#  define __USE_ISOCXX11	1
+#  define __USE_ISOC99	1
+# endif
+#endif
+
+/* If none of the ANSI/POSIX macros are defined, or if _DEFAULT_SOURCE
+   is defined, use POSIX.1-2008 (or another version depending on
+   _XOPEN_SOURCE).  */
+#ifdef _DEFAULT_SOURCE
+# if !defined _POSIX_SOURCE && !defined _POSIX_C_SOURCE
+#  define __USE_POSIX_IMPLICITLY	1
+# endif
+# undef  _POSIX_SOURCE
+# define _POSIX_SOURCE	1
+# undef  _POSIX_C_SOURCE
+# define _POSIX_C_SOURCE	200809L
+#endif
+
+#if ((!defined __STRICT_ANSI__					\
+      || (defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) >= 500))	\
+     && !defined _POSIX_SOURCE && !defined _POSIX_C_SOURCE)
+# define _POSIX_SOURCE	1
+# if defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) < 500
+#  define _POSIX_C_SOURCE	2
+# elif defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) < 600
+#  define _POSIX_C_SOURCE	199506L
+# elif defined _XOPEN_SOURCE && (_XOPEN_SOURCE - 0) < 700
+#  define _POSIX_C_SOURCE	200112L
+# else
+#  define _POSIX_C_SOURCE	200809L
+# endif
+# define __USE_POSIX_IMPLICITLY	1
+#endif
+
+/* Some C libraries once required _REENTRANT and/or _THREAD_SAFE to be
+   defined in all multithreaded code.  GNU libc has not required this
+   for many years.  We now treat them as compatibility synonyms for
+   _POSIX_C_SOURCE=199506L, which is the earliest level of POSIX with
+   comprehensive support for multithreaded code.  Using them never
+   lowers the selected level of POSIX conformance, only raises it.  */
+#if ((!defined _POSIX_C_SOURCE || (_POSIX_C_SOURCE - 0) < 199506L) \
+     && (defined _REENTRANT || defined _THREAD_SAFE))
+# define _POSIX_SOURCE   1
+# undef  _POSIX_C_SOURCE
+# define _POSIX_C_SOURCE 199506L
+#endif
+
+#if (defined _POSIX_SOURCE					\
+     || (defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 1)	\
+     || defined _XOPEN_SOURCE)
+# define __USE_POSIX	1
+#endif
+
+#if defined _POSIX_C_SOURCE && _POSIX_C_SOURCE >= 2 || defined _XOPEN_SOURCE
+# define __USE_POSIX2	1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 199309L
+# define __USE_POSIX199309	1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 199506L
+# define __USE_POSIX199506	1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 200112L
+# define __USE_XOPEN2K		1
+# undef __USE_ISOC95
+# define __USE_ISOC95		1
+# undef __USE_ISOC99
+# define __USE_ISOC99		1
+#endif
+
+#if defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE - 0) >= 200809L
+# define __USE_XOPEN2K8		1
+# undef  _ATFILE_SOURCE
+# define _ATFILE_SOURCE	1
+#endif
+
+#ifdef	_XOPEN_SOURCE
+# define __USE_XOPEN	1
+# if (_XOPEN_SOURCE - 0) >= 500
+#  define __USE_XOPEN_EXTENDED	1
+#  define __USE_UNIX98	1
+#  undef _LARGEFILE_SOURCE
+#  define _LARGEFILE_SOURCE	1
+#  if (_XOPEN_SOURCE - 0) >= 600
+#   if (_XOPEN_SOURCE - 0) >= 700
+#    define __USE_XOPEN2K8	1
+#    define __USE_XOPEN2K8XSI	1
+#   endif
+#   define __USE_XOPEN2K	1
+#   define __USE_XOPEN2KXSI	1
+#   undef __USE_ISOC95
+#   define __USE_ISOC95		1
+#   undef __USE_ISOC99
+#   define __USE_ISOC99		1
+#  endif
+# else
+#  ifdef _XOPEN_SOURCE_EXTENDED
+#   define __USE_XOPEN_EXTENDED	1
+#  endif
+# endif
+#endif
+
+#ifdef _LARGEFILE_SOURCE
+# define __USE_LARGEFILE	1
+#endif
+
+#ifdef _LARGEFILE64_SOURCE
+# define __USE_LARGEFILE64	1
+#endif
+
+#if defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64
+# define __USE_FILE_OFFSET64	1
+#endif
+
+#if defined _DEFAULT_SOURCE
+# define __USE_MISC	1
+#endif
+
+#ifdef	_ATFILE_SOURCE
+# define __USE_ATFILE	1
+#endif
+
+#ifdef	_GNU_SOURCE
+# define __USE_GNU	1
+#endif
+
+#if defined _FORTIFY_SOURCE && _FORTIFY_SOURCE > 0 \
+    && __GNUC_PREREQ (4, 1) && defined __OPTIMIZE__ && __OPTIMIZE__ > 0
+# if _FORTIFY_SOURCE > 1
+#  define __USE_FORTIFY_LEVEL 2
+# else
+#  define __USE_FORTIFY_LEVEL 1
+# endif
+#else
+# define __USE_FORTIFY_LEVEL 0
+#endif
+
+/* The function 'gets' existed in C89, but is impossible to use
+   safely.  It has been removed from ISO C11 and ISO C++14.  Note: for
+   compatibility with various implementations of <cstdio>, this test
+   must consider only the value of __cplusplus when compiling C++.  */
+#if defined __cplusplus ? __cplusplus >= 201402L : defined __USE_ISOC11
+# define __GLIBC_USE_DEPRECATED_GETS 0
+#else
+# define __GLIBC_USE_DEPRECATED_GETS 1
+#endif
+
+/* This macro indicates that the installed library is the GNU C Library.
+   For historic reasons the value now is 6 and this will stay from now
+   on.  The use of this variable is deprecated.  Use __GLIBC__ and
+   __GLIBC_MINOR__ now (see below) when you want to test for a specific
+   GNU C library version and use the values in <gnu/lib-names.h> to get
+   the sonames of the shared libraries.  */
+#undef  __GNU_LIBRARY__
+#define __GNU_LIBRARY__ 6
+
+/* Major and minor version number of the GNU C library package.  Use
+   these macros to test for features in specific releases.  */
+#define	__GLIBC__	2
+#define	__GLIBC_MINOR__	27
+
+#define __GLIBC_PREREQ(maj, min) \
+	((__GLIBC__ << 16) + __GLIBC_MINOR__ >= ((maj) << 16) + (min))
+
+/* This is here only because every header file already includes this one.  */
+#ifndef __ASSEMBLER__
+# ifndef _SYS_CDEFS_H
+#  include <sys/cdefs.h>
+# endif
+
+/* If we don't have __REDIRECT, prototypes will be missing if
+   __USE_FILE_OFFSET64 but not __USE_LARGEFILE[64]. */
+# if defined __USE_FILE_OFFSET64 && !defined __REDIRECT
+#  define __USE_LARGEFILE	1
+#  define __USE_LARGEFILE64	1
+# endif
+
+#endif	/* !ASSEMBLER */
+
+/* Decide whether we can define 'extern inline' functions in headers.  */
+#if __GNUC_PREREQ (2, 7) && defined __OPTIMIZE__ \
+    && !defined __OPTIMIZE_SIZE__ && !defined __NO_INLINE__ \
+    && defined __extern_inline
+# define __USE_EXTERN_INLINES	1
+#endif
+
+#endif	/* features.h  */

--- a/library/include/glob.h
+++ b/library/include/glob.h
@@ -2,7 +2,8 @@
 #ifndef _GLOB_H_
 #define	_GLOB_H_
 
-#include <sys/cdefs.h>
+#include <features.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -40,7 +41,6 @@ typedef struct {
 #define	GLOB_NOMATCH    (-3)	/* No match, and GLOB_NOCHECK was not set. */
 #define	GLOB_NOSYS      (-4)	/* Implementation does not support function. */
 
-#if !defined(_POSIX_SOURCE) && !defined(_XOPEN_SOURCE)
 #define	GLOB_ALTDIRFUNC 0x0040	/* Use alternately specified directory funcs. */
 #define	GLOB_BRACE      0x0080	/* Expand braces ala csh. */
 #define	GLOB_MAGCHAR    0x0100	/* Pattern had globbing characters. */
@@ -50,7 +50,6 @@ typedef struct {
 #define	GLOB_QUOTE      0x0000	/* source compatibility */
 
 #define	GLOB_ABEND GLOB_ABORTED	/* source compatibility */
-#endif
 
 __BEGIN_DECLS
 

--- a/library/include/netdb.h
+++ b/library/include/netdb.h
@@ -42,6 +42,7 @@
 #define _NETDB_H
 
 /****************************************************************************/
+#include <features.h>
 
 #ifndef _SYS_SOCKET_H
 #include <sys/socket.h>
@@ -237,7 +238,7 @@ errors[] = {
     	{EAI_NOTCANCELED, 	"Request not canceled" },
     	{EAI_ALLDONE, 		"All requests done" },
     	{EAI_INTR, 		"Interrupted by a signal" },
-    	{EAI_IDN_ENCODE, 	"Parameter string not correctly encoded" }
+    	{EAI_IDN_ENCODE, 	"Parameter string not correctly encoded" },
 #endif
         {0,                     NULL},
 };

--- a/library/include/sys/sem.h
+++ b/library/include/sys/sem.h
@@ -1,5 +1,5 @@
 /*
- * $Id: semaphore.h,v 1.00 2021-01-17 12:09:49 apalmate Exp $
+ * $Id: sem.h,v 1.00 2021-02-02 17:03:49 apalmate Exp $
  *
  * :ts=4
  *
@@ -38,24 +38,44 @@
  *****************************************************************************
  */
 
-#ifndef _SEMAPHORE_H
-#define _SEMAPHORE_H
+#ifndef _SYS_SEM_H
+#define _SYS_SEM_H
 
-#include <sys/cdefs.h>
-#include <stdlib.h>
+#include <features.h>
+/* Get common definition of System V style IPC.  */
+#include <sys/ipc.h>
+
+/* The following System V style IPC functions implement a semaphore
+   handling.  The definition is found in XPG2.  */
+
+/* Structure used for argument to `semop' to describe operations.  */
+struct sembuf
+{
+    unsigned short int sem_num; /* semaphore number */
+    short int sem_op;           /* semaphore operation */
+    short int sem_flg;          /* operation flag */
+};
 
 __BEGIN_DECLS
 
-typedef void *sem_t;
+/* Semaphore control operation.  */
+extern int _semctl(int semid, int semnum, int cmd, union semun aun);
+/* Get semaphore.  */
+extern int _semget(key_t key, int nsems, int flags);
+/* Operate on semaphore.  */
+extern int _semop(int semid, const struct sembuf *ops, int nops);
+#ifdef __USE_GNU
+/* Operate on semaphore with timeout.  */
+extern int _semtimedop(int semid, const struct sembuf *ops, int nops, struct timespec *to);
+#endif
 
-extern int sem_init(sem_t *sem, int pshared, unsigned int value);
-extern int sem_destroy(sem_t *sem);
-extern int sem_trywait(sem_t *sem);
-extern int sem_wait(sem_t *sem);
-extern int sem_timedwait(sem_t *sem, const struct timespec *timeout);
-extern int sem_post(sem_t *sem);
-extern int sem_getvalue(sem_t *sem, int *sval);
+#define semctl(a, b, c, d)     _semctl(a, b, c, d)
+#define semget(a, b, c)        _semget(a, b, c)
+#define semop(a, b, c)         _semop(a, b, c)
+#ifdef __USE_GNU
+#define semtimedop(a, b, c, d) _semtimedop(a, b, c, d)
+#endif
 
 __END_DECLS
 
-#endif
+#endif /* sys/sem.h */

--- a/library/include/sys/shm.h
+++ b/library/include/sys/shm.h
@@ -112,15 +112,6 @@ struct msqid_ds
 
 #define SEM_UNDO 020000
 
-/* for semop() */
-
-struct sembuf
-{
-    uint16_t sem_num;
-    int16_t sem_op;
-    int16_t sem_flg;
-};
-
 struct semid_ds
 {
     struct ipc_perm sem_perm;

--- a/library/include/sys/time.h
+++ b/library/include/sys/time.h
@@ -1,55 +1,21 @@
-/*
- * $Id: time.h,v 1.11 2006-01-08 12:06:14 obarthel Exp $
- *
- * :ts=4
- *
- * Portable ISO 'C' (1994) runtime library for the Amiga computer
- * Copyright (c) 2002-2015 by Olaf Barthel <obarthel (at) gmx.net>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   - Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *
- *   - Neither the name of Olaf Barthel nor the names of contributors
- *     may be used to endorse or promote products derived from this
- *     software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
- *****************************************************************************
- *
- * Documentation and source code for this library, and the most recent library
- * build are available from <https://github.com/afxgroup/clib2>.
- *
- *****************************************************************************
- */
-
 #ifndef _SYS_TIME_H
 #define _SYS_TIME_H
 
-/****************************************************************************/
+#include <features.h>
 
-/* The following is not part of the ISO 'C' (1994) standard. */
+__BEGIN_DECLS
 
-/****************************************************************************/
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
+#ifdef __USE_GNU
+/* Macros for converting between `struct timeval' and `struct timespec'.  */
+# define TIMEVAL_TO_TIMESPEC(tv, ts) {                                   \
+        (ts)->tv_sec = (tv)->tv_sec;                                    \
+        (ts)->tv_nsec = (tv)->tv_usec * 1000;                           \
+}
+# define TIMESPEC_TO_TIMEVAL(tv, ts) {                                   \
+        (tv)->tv_sec = (ts)->tv_sec;                                    \
+        (tv)->tv_usec = (ts)->tv_nsec / 1000;                           \
+}
+#endif
 
 /****************************************************************************/
 
@@ -140,12 +106,36 @@ struct timezone
 
 int gettimeofday(struct timeval *tp, struct timezone *tzp);
 
-/****************************************************************************/
+#ifdef __USE_MISC
+/* Convenience macros for operations on timevals.
+   NOTE: `timercmp' does not work for >= or <=.  */
+# define timerisset(tvp)        ((tvp)->tv_sec || (tvp)->tv_usec)
+# define timerclear(tvp)        ((tvp)->tv_sec = (tvp)->tv_usec = 0)
+# define timercmp(a, b, CMP)                                                  \
+  (((a)->tv_sec == (b)->tv_sec) ?                                             \
+   ((a)->tv_usec CMP (b)->tv_usec) :                                          \
+   ((a)->tv_sec CMP (b)->tv_sec))
+# define timeradd(a, b, result)                                               \
+  do {                                                                        \
+    (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;                             \
+    (result)->tv_usec = (a)->tv_usec + (b)->tv_usec;                          \
+    if ((result)->tv_usec >= 1000000)                                         \
+      {                                                                       \
+        ++(result)->tv_sec;                                                   \
+        (result)->tv_usec -= 1000000;                                         \
+      }                                                                       \
+  } while (0)
+# define timersub(a, b, result)                                               \
+  do {                                                                        \
+    (result)->tv_sec = (a)->tv_sec - (b)->tv_sec;                             \
+    (result)->tv_usec = (a)->tv_usec - (b)->tv_usec;                          \
+    if ((result)->tv_usec < 0) {                                              \
+      --(result)->tv_sec;                                                     \
+      (result)->tv_usec += 1000000;                                           \
+    }                                                                         \
+  } while (0)
+#endif  /* Misc.  */
 
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
+__END_DECLS
 
-/****************************************************************************/
-
-#endif /* _SYS_TIME_H */
+#endif /* sys/time.h */

--- a/library/libc.gmk
+++ b/library/libc.gmk
@@ -104,6 +104,10 @@ C_LIB := \
 	shm_shmdt.o \
 	shm_shmget.o \
 	shm_shmids.o \
+	sys_semctl.o \
+	sys_semget.o \
+	sys_semop.o \
+	sys_semtimedop.o \
 	signal_checkabort.o \
 	signal_data.o \
 	signal_kill.o \

--- a/library/shm_headers.h
+++ b/library/shm_headers.h
@@ -6,6 +6,7 @@
 #include <sys/shm.h>
 #include <sys/ipc.h>
 #include <sys/msg.h>
+#include <sys/sem.h>
 
 #ifndef _STDLIB_SYSVBASE_H
 #include "stdlib_sysvbase.h"

--- a/library/sys_semctl.c
+++ b/library/sys_semctl.c
@@ -1,5 +1,5 @@
 /*
- * $Id: unistd_sleep.c,v 1.6 2006-01-08 12:04:27 obarthel Exp $
+ * $Id: sys_semctl.c,v 1.00 2021-02-02 17:07:00 apalmate Exp $
  *
  * :ts=4
  *
@@ -29,36 +29,37 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************
+ *
+ * Documentation and source code for this library, and the most recent library
+ * build are available from <https://github.com/afxgroup/clib2>.
+ *
+ *****************************************************************************
  */
 
-#ifndef _UNISTD_HEADERS_H
-#include "unistd_headers.h"
-#endif /* _UNISTD_HEADERS_H */
+#ifndef _SHM_HEADERS_H
+#include "shm_headers.h"
+#endif /* _SHM_HEADERS_H */
 
-/****************************************************************************/
-
-/* The following is not part of the ISO 'C' (1994) standard. */
-
-/****************************************************************************/
-
-unsigned int
-sleep(unsigned int seconds)
+int 
+_semctl(int semid, int semnum, int cmd, union semun aun)
 {
-	unsigned int result;
+    DECLARE_SYSVYBASE();
+        
+    int ret = -1;
+    if (__global_clib2->haveShm)
+    {
+        ret = semctl(semid, semnum, cmd, aun);
+        if (ret < 0)
+        {
+            __set_errno(GetIPCErr());
+        }
+    }
+    else
+    {
+        __set_errno(ENOSYS);
+    }
 
-	ENTER();
-
-	SHOWVALUE(seconds);
-
-	int microseconds = seconds * 1000000;
-	SHOWVALUE(microseconds);
-
-	struct timeval tv;
-	tv.tv_sec = 0;
-	tv.tv_usec = microseconds;
-
-	result = __time_delay(TR_ADDREQUEST, &tv); // EINTR can be returned inside the call
-
-	RETURN(result);
-	return(result);
+    return ret;
 }

--- a/library/sys_semget.c
+++ b/library/sys_semget.c
@@ -1,5 +1,5 @@
 /*
- * $Id: unistd_sleep.c,v 1.6 2006-01-08 12:04:27 obarthel Exp $
+ * $Id: sys_semget.c,v 1.00 2021-02-02 17:39:33 apalmate Exp $
  *
  * :ts=4
  *
@@ -29,36 +29,38 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************
+ *
+ * Documentation and source code for this library, and the most recent library
+ * build are available from <https://github.com/afxgroup/clib2>.
+ *
+ *****************************************************************************
  */
 
-#ifndef _UNISTD_HEADERS_H
-#include "unistd_headers.h"
-#endif /* _UNISTD_HEADERS_H */
+#ifndef _SHM_HEADERS_H
+#include "shm_headers.h"
+#endif /* _SHM_HEADERS_H */
 
-/****************************************************************************/
-
-/* The following is not part of the ISO 'C' (1994) standard. */
-
-/****************************************************************************/
-
-unsigned int
-sleep(unsigned int seconds)
+int 
+_semget(key_t key, int nsems, int flags)
 {
-	unsigned int result;
+    DECLARE_SYSVYBASE();
 
-	ENTER();
+    int ret = -1;
+    if (__global_clib2->haveShm)
+    {
+        ret = semget(key, nsems, flags);
+        if (ret < 0)
+        {
+            __set_errno(GetIPCErr());
+        }
+        return (ret);
+    }
+    else
+    {
+        __set_errno(ENOSYS);
+    }
 
-	SHOWVALUE(seconds);
-
-	int microseconds = seconds * 1000000;
-	SHOWVALUE(microseconds);
-
-	struct timeval tv;
-	tv.tv_sec = 0;
-	tv.tv_usec = microseconds;
-
-	result = __time_delay(TR_ADDREQUEST, &tv); // EINTR can be returned inside the call
-
-	RETURN(result);
-	return(result);
+    return ret;
 }

--- a/library/sys_semop.c
+++ b/library/sys_semop.c
@@ -1,5 +1,5 @@
 /*
- * $Id: unistd_sleep.c,v 1.6 2006-01-08 12:04:27 obarthel Exp $
+ * $Id: sys_semop.c,v 1.00 2021-02-02 17:36:42 apalmate Exp $
  *
  * :ts=4
  *
@@ -29,36 +29,37 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************
+ *
+ * Documentation and source code for this library, and the most recent library
+ * build are available from <https://github.com/afxgroup/clib2>.
+ *
+ *****************************************************************************
  */
 
-#ifndef _UNISTD_HEADERS_H
-#include "unistd_headers.h"
-#endif /* _UNISTD_HEADERS_H */
+#ifndef _SHM_HEADERS_H
+#include "shm_headers.h"
+#endif /* _SHM_HEADERS_H */
 
-/****************************************************************************/
-
-/* The following is not part of the ISO 'C' (1994) standard. */
-
-/****************************************************************************/
-
-unsigned int
-sleep(unsigned int seconds)
+int 
+_semop(int semid, const struct sembuf *ops, int nops)
 {
-	unsigned int result;
+    DECLARE_SYSVYBASE();
 
-	ENTER();
+    int ret = -1;
+    if (__global_clib2->haveShm)
+    {
+        ret = semop(semid, ops, nops);
+        if (ret < 0)
+        {
+            __set_errno(GetIPCErr());
+        }
+    }
+    else
+    {
+        __set_errno(ENOSYS);
+    }
 
-	SHOWVALUE(seconds);
-
-	int microseconds = seconds * 1000000;
-	SHOWVALUE(microseconds);
-
-	struct timeval tv;
-	tv.tv_sec = 0;
-	tv.tv_usec = microseconds;
-
-	result = __time_delay(TR_ADDREQUEST, &tv); // EINTR can be returned inside the call
-
-	RETURN(result);
-	return(result);
+    return ret;
 }

--- a/library/sys_semtimedop.c
+++ b/library/sys_semtimedop.c
@@ -1,5 +1,5 @@
 /*
- * $Id: unistd_sleep.c,v 1.6 2006-01-08 12:04:27 obarthel Exp $
+ * $Id: sys_semtimedop.c,v 1.00 2021-02-02 17:26:15 apalmate Exp $
  *
  * :ts=4
  *
@@ -29,36 +29,37 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************
+ *
+ * Documentation and source code for this library, and the most recent library
+ * build are available from <https://github.com/afxgroup/clib2>.
+ *
+ *****************************************************************************
  */
 
-#ifndef _UNISTD_HEADERS_H
-#include "unistd_headers.h"
-#endif /* _UNISTD_HEADERS_H */
+#ifndef _SHM_HEADERS_H
+#include "shm_headers.h"
+#endif /* _SHM_HEADERS_H */
 
-/****************************************************************************/
-
-/* The following is not part of the ISO 'C' (1994) standard. */
-
-/****************************************************************************/
-
-unsigned int
-sleep(unsigned int seconds)
+int 
+_semtimedop(int semid, const struct sembuf *ops, int nops, struct timespec *to)
 {
-	unsigned int result;
+    DECLARE_SYSVYBASE();
 
-	ENTER();
+    int ret = -1;
+    if (__global_clib2->haveShm)
+    {
+        ret = semtimedop(semid, ops, nops, to);
+        if (ret < 0)
+        {
+            __set_errno(GetIPCErr());
+        }
+    }
+    else
+    {
+        __set_errno(ENOSYS);
+    }
 
-	SHOWVALUE(seconds);
-
-	int microseconds = seconds * 1000000;
-	SHOWVALUE(microseconds);
-
-	struct timeval tv;
-	tv.tv_sec = 0;
-	tv.tv_usec = microseconds;
-
-	result = __time_delay(TR_ADDREQUEST, &tv); // EINTR can be returned inside the call
-
-	RETURN(result);
-	return(result);
+    return ret;
 }

--- a/library/time_nanosleep.c
+++ b/library/time_nanosleep.c
@@ -1,5 +1,5 @@
 /*
- * $Id: unistd_usleep.c,v 1.3 2006-01-08 12:04:27 obarthel Exp $
+ * $Id: unistd_usleep.c,v 1.4 2021-02-02 18:49:27 apalmate Exp $
  *
  * :ts=4
  *
@@ -48,15 +48,13 @@
 int 
 nanosleep(const struct timespec *req, struct timespec *rem)
 {
+        struct timeval tv;
         ENTER();
 
-	unsigned long microseconds = (req->tv_sec * 1000000) + (req->tv_nsec / 1000);
+        TIMESPEC_TO_TIMEVAL(&tv, req);
 
-        SHOWVALUE(microseconds);
+        int result = __time_delay(TR_ADDREQUEST, &tv); // EINTR can be returned inside the call
 
-	// errno is set in __time_delay if it is break by a signal
-        __time_delay(0,microseconds);
-
-        RETURN(0);
-        return 0;
+        RETURN(result);
+        return result;
 }

--- a/library/unistd_headers.h
+++ b/library/unistd_headers.h
@@ -109,7 +109,7 @@ extern int __strip_double_slash(char * file_name,int len);
 
 /****************************************************************************/
 
-extern unsigned int __time_delay(unsigned long seconds,unsigned long microseconds);
+extern int __time_delay(ULONG timercmd, struct timeval *tv);
 
 /****************************************************************************/
 

--- a/library/unistd_time_delay.c
+++ b/library/unistd_time_delay.c
@@ -47,113 +47,66 @@
 
 /****************************************************************************/
 
-/* A quick workaround for the timeval/timerequest->TimeVal/TimeRequest
-   change in the recent OS4 header files. */
+/* amiga_dotimer.c is a different implementation and use a different timer.device
+ * we can't use the same implementation because it pass a Unit parameter.
+ * However SIGBREAKF_CTRL_C handling should be implemented in the same way
+ */
 
-#if defined(__NEW_TIMEVAL_DEFINITION_USED__)
-
-#define timeval		TimeVal
-#define tv_secs		Seconds
-#define tv_micro	Microseconds
-
-#define timerequest	TimeRequest
-#define tr_node		Request
-#define tr_time		Time
-
-#endif /* __NEW_TIMEVAL_DEFINITION_USED__ */
-
-/****************************************************************************/
-
-unsigned int
-__time_delay(unsigned long seconds,unsigned long microseconds)
+int 
+__time_delay(ULONG timercmd, struct timeval *tv)
 {
-	unsigned int result = 0;
-
 	ENTER();
 
-	SHOWVALUE(seconds);
+	struct MsgPort *mp;
+	struct TimeRequest *tr;
+	ULONG wait_mask;
+	int result = 0;
 
-	if(__check_abort_enabled)
+	if (__check_abort_enabled)
 		__check_abort();
 
-	if((seconds > 0 || microseconds > 0) && NOT __timer_busy)
+	if (__timer_request == NULL)
+		return EINVAL;
+
+	SetSignal(0, SIGB_SINGLE | SIGBREAKF_CTRL_C);
+
+	mp = AllocSysObjectTags(ASOT_PORT,
+							ASOPORT_AllocSig, FALSE,
+							ASOPORT_Signal, SIGB_SINGLE,
+							TAG_DONE);
+
+	tr = AllocSysObjectTags(ASOT_IOREQUEST,
+							ASOIOR_Duplicate, __timer_request,
+							ASOIOR_ReplyPort, mp,
+							ASOIOR_Size, sizeof(struct TimeRequest),
+							TAG_END);
+	if (!tr)
 	{
-		#if defined(__amigaos4__)
-		struct TimerIFace * ITimer = __ITimer;
-		#else
-		struct Library * TimerBase = __TimerBase;
-		#endif /* __amigaos4__ */
-
-		ULONG signals_to_wait_for;
-		ULONG seconds_then;
-		ULONG timer_signal;
-		struct timeval tv;
-		ULONG signals;
-
-		__timer_busy = TRUE;
-
-		__timer_request->tr_node.io_Command	= TR_ADDREQUEST;
-		__timer_request->tr_time.tv_secs	= seconds;
-		__timer_request->tr_time.tv_micro	= microseconds;
-
-		timer_signal = (1UL << __timer_port->mp_SigBit);
-
-		signals_to_wait_for = timer_signal;
-
-		SetSignal(0,signals_to_wait_for);
-
-		if(__check_abort_enabled)
-			SET_FLAG(signals_to_wait_for,__break_signal_mask);
-
-		PROFILE_OFF();
-		GetSysTime(&tv);
-		PROFILE_ON();
-
-		seconds_then = tv.tv_secs + seconds;
-
-		SendIO((struct IORequest *)__timer_request);
-
-		while(TRUE)
-		{
-			PROFILE_OFF();
-			signals = Wait(signals_to_wait_for);
-			PROFILE_ON();
-
-			if(FLAG_IS_SET(signals,__break_signal_mask))
-			{
-				ULONG seconds_now;
-
-				if(CheckIO((struct IORequest *)__timer_request) == BUSY)
-					AbortIO((struct IORequest *)__timer_request);
-
-				WaitIO((struct IORequest *)__timer_request);
-
-				SetSignal(__break_signal_mask,__break_signal_mask);
-				__check_abort();
-
-				/* Now figure out how many seconds have elapsed and
-				   how many would still remain. */
-				PROFILE_OFF();
-				GetSysTime(&tv);
-				PROFILE_ON();
-
-				seconds_now = tv.tv_secs;
-				if(seconds_now < seconds_then)
-					result = seconds_then - seconds_now;
-
-				break;
-			}
-
-			if(FLAG_IS_SET(signals,timer_signal))
-			{
-				WaitIO((struct IORequest *)__timer_request);
-				break;
-			}
-		}
-
-		__timer_busy = FALSE;
+		FreeSysObject(ASOT_IOREQUEST, mp);
+		return ENOMEM;
 	}
 
+	tr->Request.io_Command = timercmd;
+	tr->Time.Seconds = tv->tv_sec;
+	tr->Time.Microseconds = tv->tv_usec;
+
+	SendIO((struct IORequest *)tr);
+	wait_mask = SIGBREAKF_CTRL_C | 1L << mp->mp_SigBit;
+	if (Wait(wait_mask) & (SIGBREAKF_CTRL_C)) {
+		if (CheckIO((struct IORequest *)tr))  /* If request is complete... */
+			WaitIO((struct IORequest *)tr);   /* clean up and remove reply */
+		AbortIO((struct IORequest *)tr);
+		/* Return EINTR since the request has been interrupted */
+		result = EINTR;
+	}
+	WaitIO((struct IORequest *)tr);
+
+	tv->tv_sec = tr->Time.Seconds;
+	tv->tv_usec = tr->Time.Microseconds;
+
+	FreeSysObject(ASOT_MESSAGE, tr);
+	FreeSysObject(ASOT_PORT, mp);
+
 	RETURN(result);
-	return(result);
+	return result;
 }

--- a/library/unistd_usleep.c
+++ b/library/unistd_usleep.c
@@ -43,18 +43,16 @@
 
 int usleep(unsigned long microseconds)
 {
-	int retval = 0;
+	int retval;
 	ENTER();
 
 	SHOWVALUE(microseconds);
 
-	__time_delay(0, microseconds);
+	struct timeval tv;
+	tv.tv_sec = 0;
+	tv.tv_usec = microseconds;
 
-	// errno is set in __time_delay if it is break by a signal
-	if (errno != 0)
-		retval = -1;
-
-	LEAVE();
+	retval = __time_delay(TR_ADDREQUEST, &tv); // EINTR can be returned inside the call
 
 	RETURN(retval);
 	return retval;

--- a/test_programs/Makefile
+++ b/test_programs/Makefile
@@ -70,7 +70,7 @@ ${BUILDDIR}:
 
 simple_sprintf : simple_sprintf
 	@echo "Linking $(BUILDDIR)/$@"
-	@$(CC) $(CFLAGS) -nostdlib -o $(BUILDDIR)/$@ simple_sprintf.o -lc -lgcc $(LFLAGS) -Wl,--cref,-M,-Map=$(BUILDDIR)/$@.map
+	@$(CC) $(CFLAGS) -nostdlib -o $(BUILDDIR)/$@ simple_sprintf.c -lc -lgcc $(LFLAGS) -Wl,--cref,-M,-Map=$(BUILDDIR)/$@.map
 
 semaphore_test : semaphore_test
 	@echo "Linking $(BUILDDIR)/$@"

--- a/test_programs/iotest.c
+++ b/test_programs/iotest.c
@@ -5,16 +5,19 @@
 #define FILE_SIZE 2048
 #define WRITE_SIZE 32
 
-char FileData[FILE_SIZE];
+char FileData[FILE_SIZE] = {0};
+void CreateFile(char *filename);
+void ReadWriteFile(char *filename);
 
 void CreateFile(char *filename)
 {
    FILE *file;
 
-   if (file = fopen(filename,"w")) {
-      memset(FileData,'0',FILE_SIZE);
-      memset(FileData,'-',WRITE_SIZE);
-      fwrite(FileData,1,FILE_SIZE,file);
+   if (file = fopen(filename, "w"))
+   {
+      memset(FileData, '0', FILE_SIZE);
+      memset(FileData, '-', WRITE_SIZE);
+      fwrite(FileData, 1, FILE_SIZE, file);
       fclose(file);
    }
 }
@@ -23,19 +26,21 @@ void ReadWriteFile(char *filename)
 {
    FILE *file;
 
-   if (file = fopen(filename,"r+")) {
-      fseek(file,0,SEEK_SET);
-      fread(FileData,1,FILE_SIZE,file);
-      fseek(file,0,SEEK_SET);
-      memset(FileData,'1',WRITE_SIZE);
-      fwrite(FileData,1,WRITE_SIZE,file);
+   if (file = fopen(filename, "r+"))
+   {
+      fseek(file, 0, SEEK_SET);
+      fread(FileData, 1, FILE_SIZE, file);
+      fseek(file, 0, SEEK_SET);
+      memset(FileData, '1', WRITE_SIZE);
+      fwrite(FileData, 1, WRITE_SIZE, file);
       fclose(file);
    }
 }
 
 int main(int argc, char **argv)
 {
-   if (argc > 1) {
+   if (argc > 1)
+   {
       CreateFile(argv[1]);
       ReadWriteFile(argv[1]);
    }

--- a/test_programs/printf_test.c
+++ b/test_programs/printf_test.c
@@ -2,6 +2,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+void print_format_int(const char * format_string,int parameter1,int parameter2);
+void print_format_char(const char * format_string,char parameter);
+void print_format_string(const char * format_string,const char *parameter1,const char *parameter2);
+void print_format_float(const char * format_string,double parameter1,double parameter2);
+
 double x;
 
 void

--- a/test_programs/pthread_join.c
+++ b/test_programs/pthread_join.c
@@ -1,55 +1,57 @@
 #include <pthread.h> // for pthread_create, pthread_join, pthread_exit
-#include <stdio.h>   // for printf 
+#include <stdio.h>   // for printf
 #include <stdlib.h>  // for exit
 
 #define NITER 100000
 
+void *Count(void *a);
+
 int cnt = 0;
 
-void * Count(void * a)
+void *Count(void *a)
 {
     int i, tmp;
-    for(i = 0; i < NITER; i++)   
+    for (i = 0; i < NITER; i++)
     {
-        tmp = cnt;      /* copy the global cnt locally */
-        tmp = tmp+1;    /* increment the local copy */
-        cnt = tmp;      /* store the local value into the global cnt */ 
+        tmp = cnt;     /* copy the global cnt locally */
+        tmp = tmp + 1; /* increment the local copy */
+        cnt = tmp;     /* store the local value into the global cnt */
     }
 }
 
-int main(int argc, char * argv[])
+int main(int argc, char *argv[])
 {
     pthread_t tid1, tid2;
 
-    if(pthread_create(&tid1, NULL, Count, NULL))
+    if (pthread_create(&tid1, NULL, Count, NULL))
     {
         printf("\n ERROR creating thread 1");
         exit(1);
     }
 
-    if(pthread_create(&tid2, NULL, Count, NULL))
+    if (pthread_create(&tid2, NULL, Count, NULL))
     {
         printf("\n ERROR creating thread 2");
         exit(1);
     }
 
-    if(pthread_join(tid1, NULL))        /* wait for the thread 1 to finish */
+    if (pthread_join(tid1, NULL)) /* wait for the thread 1 to finish */
     {
         printf("\n ERROR joining thread");
         exit(1);
     }
 
-    if(pthread_join(tid2, NULL))        /* wait for the thread 2 to finish */
+    if (pthread_join(tid2, NULL)) /* wait for the thread 2 to finish */
     {
         printf("\n ERROR joining thread");
         exit(1);
     }
 
-    if (cnt < 2 * NITER) 
-        printf("\n BOOM! cnt is [%d], should be %d\n", cnt, 2*NITER);
+    if (cnt < 2 * NITER)
+        printf("\n BOOM! cnt is [%d], should be %d\n", cnt, 2 * NITER);
     else
         printf("\n OK! cnt is [%d]\n", cnt);
-  
+
     pthread_exit(NULL);
     return 0;
 }

--- a/test_programs/semaphore_test.c
+++ b/test_programs/semaphore_test.c
@@ -1,9 +1,10 @@
-// C program to demonstrate working of Semaphores
+// C program to demonstrate working of Semaphores - this fail on newlib if you press CTRL-C while should work with clib2
 #include <stdio.h>
 #include <pthread.h>
 #include <semaphore.h>
 #include <unistd.h>
 
+void *thread(void *arg);
 sem_t mutex;
 
 void *thread(void *arg)

--- a/test_programs/sprintf_test.c
+++ b/test_programs/sprintf_test.c
@@ -1,7 +1,9 @@
 #include <string.h>
 #include <stdio.h>
 
-static char buf[256];
+static char buf[256] = {0};
+
+void addsomething(void);
 
 void addsomething(void)
 {

--- a/test_programs/test.c
+++ b/test_programs/test.c
@@ -17,6 +17,13 @@
 #include <math.h>
 #include <sys/stat.h>
 
+void __attribute__ ((constructor)) constructor_test1(void);
+void __attribute__ ((constructor)) constructor_test2(void);
+void __attribute__ ((constructor)) constructor_test3(void);
+void __attribute__ ((destructor)) destructor_test1(void);
+void __attribute__ ((destructor)) destructor_test2(void);
+void __attribute__ ((destructor)) destructor_test3(void);
+
 /****************************************************************************/
 
 /*int __stack_size = 20000;*/


### PR DESCRIPTION
Fixed __time_delay and changing all time functions with this implementation. Now it works correctly with semaphore_test example. Previous version just will hang.
Not only. Now CTRL_C works corectly and interrupt the pthread correclty (an return also EINTR correctly) without any crash