### PR TITLE
pedantic will show no statement after last label as a compiler error

### DIFF
--- a/library/stdio/flockfile.c
+++ b/library/stdio/flockfile.c
@@ -35,5 +35,5 @@ flockfile(FILE *stream) {
         ObtainSemaphore(file->iob_Lock);
 
 out:
-
+    return;
 }

--- a/library/stdio/funlockfile.c
+++ b/library/stdio/funlockfile.c
@@ -33,5 +33,5 @@ funlockfile(FILE *stream) {
         ReleaseSemaphore(file->iob_Lock);
 
 out:
-
+    return;
 }


### PR DESCRIPTION
pedantic will show no statement after last label as a compiler error