### PR TITLE
Fix unistd access.

### DIFF
--- a/library/include/unistd.h
+++ b/library/include/unistd.h
@@ -27,10 +27,10 @@ __BEGIN_DECLS
 #define STDOUT_FILENO	1
 #define STDERR_FILENO	2
 
-#define R_OK 0
-#define W_OK 1
-#define X_OK 2
-#define F_OK 4
+#define F_OK 0
+#define X_OK 1
+#define W_OK 2
+#define R_OK 4
 
 #define F_ULOCK	0
 #define F_LOCK	1

--- a/library/unistd/access.c
+++ b/library/unistd/access.c
@@ -104,7 +104,7 @@ access(const char *path_name, int mode) {
         }
 
         if (FLAG_IS_SET(mode, R_OK)) {
-            if (FLAG_IS_SET(status->Protection, EXDB_NO_READ)) {
+            if (FLAG_IS_SET(status->Protection, EXDF_NO_READ)) {
                 SHOWMSG("not readable");
 
                 __set_errno(EACCES);


### PR DESCRIPTION
R_OK test was broken due to bit / field confusion and bad choice of R_* values. Use the same values as newlib and glibc.