### PR TITLE
Use native GetPID() in unistd getpid().

### DIFF
--- a/library/unistd/getpid.c
+++ b/library/unistd/getpid.c
@@ -6,21 +6,12 @@
 #include "unistd_headers.h"
 #endif /* _UNISTD_HEADERS_H */
 
-pid_t 
+pid_t
 getpid(void)
 {
-	pid_t result;
-
 	ENTER();
 
-	struct Task *t = FindTask(NULL);
-
-	if (t->tc_Node.ln_Type != NT_PROCESS)
-	{
-		result = 0;
-	}
-
-	result = ((struct Process *)t)->pr_ProcessID;
+	pid_t result = (pid_t) GetPID(NULL, GPID_PROCESS);
 
 	RETURN(result);
 	return (result);


### PR DESCRIPTION
Avoid struct poking and save a few lines of code by using GetPID() in dos.library.