### PR TITLE
Don't assume that __STDC_VERSION__ is defined.

### DIFF
--- a/library/include/complex.h
+++ b/library/include/complex.h
@@ -14,7 +14,8 @@
 #warning C99 header file used in C++.
 #endif /* __cplusplus */
 
-#if !defined(__STDC_VERSION__) || (__GNUC__ < 3 && __STDC_VERSION__ < 199901L)
+#if (!defined(__STDC_VERSION__) && __GCC_IEC_559_COMPLEX < 1) || \
+    (__GNUC__ < 3 && __STDC_VERSION__ < 199901L)
 #error Complex numbers are not supported by/for this compiler.
 #endif /* __GNUC__ && __STDC_VERSION__ */
 


### PR DESCRIPTION
Don't assume that complex math isn't supported just because __STDC_VERSION__ isn't defined. This will trick configure scripts to assume that complex math isn't supported when g++ is used. By checking __GCC_IEC_559_COMPLEX as well, this problem is solved.