### PR TITLE
Don't redefine __CLIB2

### DIFF
--- a/library/include/dos.h
+++ b/library/include/dos.h
@@ -494,6 +494,7 @@ struct _clib2 {
 extern struct _clib2 *__getClib2(void);
 
 #endif
+#undef __CLIB2
 #define __CLIB2 __getClib2()
 
 /*


### PR DESCRIPTION
Undefine __CLIB2 before defining it to avoid compiler warnings.