### PR TITLE
Remove redundant NULL check in __delete_semaphore

### DIFF
--- a/library/stdlib/semaphore.c
+++ b/library/stdlib/semaphore.c
@@ -25,10 +25,7 @@ __delete_semaphore(struct SignalSemaphore *semaphore) {
     ENTER();
     SHOWPOINTER(semaphore);
 
-    if (semaphore != NULL) {
-        FreeSysObject(ASOT_SEMAPHORE, semaphore);
-        semaphore = NULL;
-    }
+    FreeSysObject(ASOT_SEMAPHORE, semaphore);
 
     LEAVE();
 }


### PR DESCRIPTION
Redundant check in __delete_semaphore. FreeSysObject can take NULL input.