### PR TITLE
Remove redundant NULL check in DeleteExtIO

### DIFF
--- a/library/amiga/deleteextio.c
+++ b/library/amiga/deleteextio.c
@@ -16,8 +16,5 @@
 VOID DeleteExtIO(struct IORequest *io);
 
 VOID DeleteExtIO(struct IORequest *io) {
-    assert(io != NULL);
-
-    if (io != NULL)
-        FreeSysObject(ASOT_IOREQUEST, io);
+    FreeSysObject(ASOT_IOREQUEST, io);
 }


### PR DESCRIPTION
Redundant check in DeleteExtIO. FreeSysObject can take NULL input.