### PR TITLE
Remove redundant NULL check in DeleteStdIO

### DIFF
--- a/library/amiga/deletestdio.c
+++ b/library/amiga/deletestdio.c
@@ -16,6 +16,5 @@
 VOID DeleteStdIO(struct IOStdReq *io);
 
 VOID DeleteStdIO(struct IOStdReq *io) {
-    if (io != NULL)
-        FreeSysObject(ASOT_IOREQUEST, io);
+    FreeSysObject(ASOT_IOREQUEST, io);
 }


### PR DESCRIPTION
Redundant check in DeleteStdIO. FreeSysObject can take NULL input.