### PR TITLE
Remove redundant NULL check in DoTimer

### DIFF
--- a/library/amiga/dotimer.c
+++ b/library/amiga/dotimer.c
@@ -77,8 +77,7 @@ out:
         FreeSysObject(ASOT_IOREQUEST, tr);
     }
 
-    if (mp != NULL)
-        FreeSysObject(ASOT_PORT, mp);
+    FreeSysObject(ASOT_PORT, mp);
 
     return (error);
 }


### PR DESCRIPTION
Redundant check in DoTimer. FreeSysObject can take NULL input.