### PR TITLE
Memory leak in langinfo

### DIFF
--- a/library/locale/langinfo.c
+++ b/library/locale/langinfo.c
@@ -41,13 +41,17 @@ nl_langinfo(nl_item item) {
                     ret = cs + 1;
                     if (strncmp(ret, "ISO_", 4) == 0) {
                         int slen = strlen(ret);
+                        char *tmp = realloc(cset, slen);
 
-                        if ((cset = realloc(cset, slen)) != NULL) {
+                        if (tmp != NULL) {
+                            cset = tmp;
                             strcpy(cset, "ISO");
                             strcat(cset, ret + 4);
                             ret = cset;
-                        } else
+                        } else {
+                            free(cset);
                             ret = "";
+                        }
                     } else if (strcmp(ret, "EUC") == 0) {
                         if (strncmp(s, "ja_JP", 5) == 0)
                             ret = "eucJP";


### PR DESCRIPTION
Current allocation will be lost when low on memory.