### PR TITLE
Remove redundant NULL check in access

### DIFF
--- a/library/unistd/access.c
+++ b/library/unistd/access.c
@@ -140,11 +140,7 @@ access(const char *path_name, int mode) {
 
 out:
 
-    if (NULL != status) {
-        FreeDosObject(DOS_EXAMINEDATA, status);
-        status = NULL;
-    }
-
+    FreeDosObject(DOS_EXAMINEDATA, status);
     UnLock(lock);
 
     RETURN(result);


### PR DESCRIPTION
FreeDosObject accepts NULL as object.