### PR TITLE
Bad initialization in btowc

### DIFF
--- a/library/wchar/btowc.c
+++ b/library/wchar/btowc.c
@@ -20,7 +20,7 @@ btowc(int c) {
     b = (char) c;
 
     /* Put mbs in initial state. */
-    memset(mbs, '\0', sizeof(mbs));
+    memset(mbs, '\0', sizeof(mbstate_t));
 
     retval = _mbtowc_r(&pwc, &b, 1, mbs);
 


### PR DESCRIPTION
Pointer size was used instead of size of datatype when clearing with memset.