### PR TITLE
Remove redundant NULL check in chown

### DIFF
--- a/library/unistd/chown.c
+++ b/library/unistd/chown.c
@@ -98,10 +98,7 @@ int chown(const char *path_name, uid_t owner, gid_t group) {
     result = OK;
 
 out:
-    if (status != NULL) {
-        FreeDosObject(DOS_EXAMINEDATA, status);
-    }
-
+    FreeDosObject(DOS_EXAMINEDATA, status);
     FreeDeviceProc(dvp);
 
     if (file_lock != BZERO)


### PR DESCRIPTION
FreeDosObject accepts NULL as object.