### PR TITLE
Remove redundant if statements in clock_gettime64

### DIFF
--- a/library/time/clock_gettime64.c
+++ b/library/time/clock_gettime64.c
@@ -32,7 +32,6 @@ clock_gettime64(clockid_t clk_id, struct timespec64 *t) {
     struct TimerIFace *ITimer = __clib2->__ITimer;
 
     struct timeval tv;
-    int result = 0;
     uint32 gmtoffset = 0;
     int8 dstime = -1;
 
@@ -40,48 +39,44 @@ clock_gettime64(clockid_t clk_id, struct timespec64 *t) {
     tv.tv_sec = tv.tv_usec = 0;
 
     GetTimezoneAttrs(NULL, TZA_UTCOffset, &gmtoffset, TZA_TimeFlag, &dstime, TAG_DONE);
-    if (result == 0) {
-        __clib2->__timer_busy = TRUE;
-        if (clk_id == CLOCK_MONOTONIC) {
-            /*
-            CLOCK_MONOTONIC
-                A nonsettable system-wide clock that represents monotonic
-                time since—as described by POSIX—"some unspecified point
-                in the past". On clib2, that point corresponds to the
-                number of seconds that the system has been running since
-                it was booted.
-            */
-            GetUpTime((struct TimeVal *) &tv);
-        } else {
-            /*
-            A settable system-wide clock that measures real (i.e.,
-                wall-clock) time.  Setting this clock requires appropriate
-                privileges.  This clock is affected by discontinuous jumps
-                in the system time (e.g., if the system administrator
-                manually changes the clock), and by the incremental
-                adjustments performed by adjtime(3) and NTP.
-            */
-            GetSysTime((struct TimeVal *) &tv);
-        }
-
-        if (result == 0) {
-            /* Use a 32 bit timespec to calculate the result */
-            struct timespec tr;
-            if (clk_id == CLOCK_MONOTONIC) {
-                tr.tv_sec = tv.tv_sec;
-                tr.tv_nsec = tv.tv_usec * 1000;
-            } else {
-                /* 2922 is the number of days between 1.1.1970 and 1.1.1978 */
-                tv.tv_sec += (2922 * 24 * 60 + gmtoffset) * 60;
-                tr.tv_sec = tv.tv_sec;
-                tr.tv_nsec = tv.tv_usec * 1000;
-            }
-            /* And then convert it to a 64bit timespec */
-            *t = valid_timespec_to_timespec64(tr);
-        }
+    __clib2->__timer_busy = TRUE;
+    if (clk_id == CLOCK_MONOTONIC) {
+        /*
+        CLOCK_MONOTONIC
+            A nonsettable system-wide clock that represents monotonic
+            time since—as described by POSIX—"some unspecified point
+            in the past". On clib2, that point corresponds to the
+            number of seconds that the system has been running since
+            it was booted.
+        */
+        GetUpTime((struct TimeVal *) &tv);
+    } else {
+        /*
+        A settable system-wide clock that measures real (i.e.,
+            wall-clock) time.  Setting this clock requires appropriate
+            privileges.  This clock is affected by discontinuous jumps
+            in the system time (e.g., if the system administrator
+            manually changes the clock), and by the incremental
+            adjustments performed by adjtime(3) and NTP.
+        */
+        GetSysTime((struct TimeVal *) &tv);
     }
 
+    /* Use a 32 bit timespec to calculate the result */
+    struct timespec tr;
+    if (clk_id == CLOCK_MONOTONIC) {
+        tr.tv_sec = tv.tv_sec;
+        tr.tv_nsec = tv.tv_usec * 1000;
+    } else {
+        /* 2922 is the number of days between 1.1.1970 and 1.1.1978 */
+        tv.tv_sec += (2922 * 24 * 60 + gmtoffset) * 60;
+        tr.tv_sec = tv.tv_sec;
+        tr.tv_nsec = tv.tv_usec * 1000;
+    }
+    /* And then convert it to a 64bit timespec */
+    *t = valid_timespec_to_timespec64(tr);
+
     __clib2->__timer_busy = FALSE;
-    RETURN(result);
-    return result;
+    RETURN(0);
+    return 0;
 }


### PR DESCRIPTION
The boolean expressions are always true.