### PR TITLE
Remove redundant NULL check in fchmod

### DIFF
--- a/library/stat/fchmod.c
+++ b/library/stat/fchmod.c
@@ -120,8 +120,7 @@ out:
     if (current_dir_changed)
         CurrentDir(old_current_dir);
 
-    if (fib != NULL)
-        FreeDosObject(DOS_EXAMINEDATA, fib);
+    FreeDosObject(DOS_EXAMINEDATA, fib);
 
     UnLock(parent_dir);
 


### PR DESCRIPTION
FreeDosObject accepts NULL as object.