### PR TITLE
Remove redundant NULL check in ftruncate(64)

### DIFF
--- a/library/unistd/ftruncate.c
+++ b/library/unistd/ftruncate.c
@@ -86,8 +86,7 @@ out:
        not change the current file position. */
     ChangeFilePosition(fd->fd_File, initial_position, OFFSET_BEGINNING);
 
-    if (fib != NULL)
-        FreeDosObject(DOS_EXAMINEDATA, fib);
+    FreeDosObject(DOS_EXAMINEDATA, fib);
 
     __fd_unlock(fd);
 

--- a/library/unistd/ftruncate64.c
+++ b/library/unistd/ftruncate64.c
@@ -87,8 +87,7 @@ out:
 	   not change the current file position. */
     ChangeFilePosition(fd->fd_File, initial_position, OFFSET_BEGINNING);
 
-    if (fib != NULL)
-        FreeDosObject(DOS_EXAMINEDATA, fib);
+    FreeDosObject(DOS_EXAMINEDATA, fib);
 
     __fd_unlock(fd);
     __stdio_unlock(__clib2);


### PR DESCRIPTION
FreeDosObject accepts NULL as object.