### PR TITLE
Remove redundant NULL check in (l)stat

### DIFF
--- a/library/stat/lstat.c
+++ b/library/stat/lstat.c
@@ -129,9 +129,7 @@ lstat(const char *path_name, struct stat *st) {
 
 out:
 
-    if (fib != NULL) {
-        FreeDosObject(DOS_EXAMINEDATA, fib);
-    }
+    FreeDosObject(DOS_EXAMINEDATA, fib);
     UnLock(file_lock);
 
     RETURN(result);

--- a/library/stat/stat.c
+++ b/library/stat/stat.c
@@ -104,10 +104,7 @@ stat(const char *path_name, struct stat *st) {
 
 out:
 
-    if (fib != NULL) {
-        FreeDosObject(DOS_EXAMINEDATA, fib);
-    }
-
+    FreeDosObject(DOS_EXAMINEDATA, fib);
     UnLock(file_lock);
 
     RETURN(result);


### PR DESCRIPTION
FreeDosObject accepts NULL as object.