### PR TITLE
Remove redundant NULL check in fcntl/open

### DIFF
--- a/library/fcntl/open.c
+++ b/library/fcntl/open.c
@@ -367,9 +367,7 @@ out:
     if (handle != BZERO)
         Close(handle);
 
-    if (fib != NULL) {
-        FreeDosObject(DOS_EXAMINEDATA, fib);
-    }
+    FreeDosObject(DOS_EXAMINEDATA, fib);
     UnLock(lock);
 
     __stdio_unlock(__clib2);


### PR DESCRIPTION
FreeDosObject accepts NULL as object.