### PR TITLE
Potential null pointer dereference

### DIFF
--- a/library/stdlib/wof_allocator.c
+++ b/library/stdlib/wof_allocator.c
@@ -532,12 +532,13 @@ wof_free_jumbo(wof_allocator_t *allocator, wof_chunk_hdr_t *chunk) {
 
     block = WOF_CHUNK_TO_BLOCK(chunk);
 
+    if(!block) {
+        return;
+    }
+
     wof_remove_from_block_list(allocator, block);
 
-    if (block) {
-        FreeVec(block);
-        block = NULL;
-    }
+    FreeVec(block);
 }
 
 /* Reallocs special 'jumbo' blocks of sizes that won't fit normally. */


### PR DESCRIPTION
A null pointer dereference will occur in wof_remove_from_block_list if block is null. Avoid this by an early exit.