### PR TITLE
Invalid comparison in wof_allocator

### DIFF
--- a/library/stdlib/wof_allocator.c
+++ b/library/stdlib/wof_allocator.c
@@ -552,7 +552,7 @@ wof_realloc_jumbo(wof_allocator_t *allocator, wof_chunk_hdr_t *chunk, const size
     block = WOF_CHUNK_TO_BLOCK(chunk);
 
     /* If we have an invalid block return NULL */
-    if (block == NULL || old_size <= 0 || size <= 0) {
+    if (block == NULL || !old_size || !size) {
         return NULL;
     }
 


### PR DESCRIPTION
Unsigned / signed mix up. The size_t variables can't be < 0.