### PR TITLE
Null pointer dereferences in record_locking

### DIFF
--- a/library/stdio/record_locking.c
+++ b/library/stdio/record_locking.c
@@ -606,6 +606,7 @@ __handle_record_locking(int cmd, struct flock *l, struct fd *fd, int *error_ptr)
         }
     } else {
         SHOWMSG("this is not a lock request");
+        goto out;
     }
 
     original_len = l->l_len;


### PR DESCRIPTION
Missing bail out when a lock request isn't a real lock request leads to null pointer dereferences on line 768 and onwards.