### PR TITLE
Append compiler options

### DIFF
--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -95,7 +95,7 @@ SHARED   := $(if $(SHARED),$(SHARED),yes)
 STATIC   := $(if $(STATIC),$(STATIC),yes)
 
 LARGEDATA :=
-OPTIONS  := $(LARGEDATA) -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D__CLIB2__ -Wa,-mregnames -fno-builtin -nostdlib -D_GNU_SOURCE -D_XOPEN_SOURCE -D_USE_GNU
+OPTIONS  += $(LARGEDATA) -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D__CLIB2__ -Wa,-mregnames -fno-builtin -nostdlib -D_GNU_SOURCE -D_XOPEN_SOURCE -D_USE_GNU
 OPTIMIZE := -O3 -mregnames -mmultiple -mupdate -mstrict-align
 
 STABS :=


### PR DESCRIPTION
Append to OPTIONS instead of setting. This makes it easier to add extra options from the command line.