### PR TITLE
Removed definition flag in C options that was -D__CLIB2__. This is no…

### DIFF
--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -101,7 +101,7 @@ SHARED   := $(if $(SHARED),$(SHARED),yes)
 STATIC   := $(if $(STATIC),$(STATIC),yes)
 
 LARGEDATA :=
-OPTIONS  += $(LARGEDATA) -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D__CLIB2__ -Wa,-mregnames -fno-builtin -nostdlib -D_GNU_SOURCE -D_XOPEN_SOURCE -D_USE_GNU -pipe
+OPTIONS  += $(LARGEDATA) -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wa,-mregnames -fno-builtin -nostdlib -D_GNU_SOURCE -D_XOPEN_SOURCE -D_USE_GNU -pipe
 OPTIMIZE := -O3 -mregnames -mmultiple -mupdate -ffp-contract=fast -mstrict-align
 
 STABS :=

--- a/library/shared_library/interface.h
+++ b/library/shared_library/interface.h
@@ -1247,7 +1247,7 @@ struct Clib4IFace {
     /* sys/utsname.h */
     int (* uname) (struct utsname *);                                                                                                                /* 4084 */
 
-    /* END OF CLIB2 VERSION 1.0   */
+    /* END OF CLIB4 VERSION 1.0   */
     /* New function will go below */
 
     int (* futimens) (int fd, const struct timespec times[2]);                                                                                       /* 4098 */

--- a/library/shared_library/stubs.c
+++ b/library/shared_library/stubs.c
@@ -1018,7 +1018,7 @@ Clib4Call(times, 4072);
 Clib4Call(readv, 4076);
 Clib4Call(writev, 4080);
 Clib4Call(uname, 4084);
-/* END OF CLIB2 VERSION 1.0   */
+/* END OF CLIB4 VERSION 1.0   */
 /* New function will go below */
 Clib4Call(futimens, 4088);
 Clib4Call(utimensat, 4092);

--- a/test_programs/misc/md5sum.c
+++ b/test_programs/misc/md5sum.c
@@ -47,7 +47,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <time.h>
-#ifdef __CLIB2__
+#ifdef __CLIB4__
 #include <endian.h>
 #else
 #include <machine/endian.h>


### PR DESCRIPTION
…w clib4, in anycase, the specs file/mcrt option implicitly define this for us. Replaced CLIB2 with CLIB4 where necessary. Did not update the specs files in misc since they are only for guidance