### PR TITLE
Added some targets that are PHONY targets. The checking of the existe…

### DIFF
--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -161,7 +161,11 @@ prepare:
 	-$(MAKEDIR) $(BUILD_DIR)/shared
 	-$(MAKEDIR) $(INSTALL_PREFIX)/lib
 	-$(MAKEDIR) $(INSTALL_PREFIX)/include
-	$(VERBOSE)which $(CC); \
+# It may be the case that this makefile is invoked with an explicit CC
+# assingment such as: "gcc -B /someDir/". In fact, this pattern is used within
+# ADTOOLS - for that reason we take the first word and apply which on that,
+# otherwise the extraneous options will cause a failure
+	$(VERBOSE)which $(word 1,$(CC)); \
 		if [ $$? -ne 0 ]; \
 		then \
 			echo "Could not locate cross compiler: '$(CC)'" 1>&2; \

--- a/GNUmakefile.os4
+++ b/GNUmakefile.os4
@@ -7,7 +7,8 @@
 
 ##############################################################################
 
-.PHONY : all all-targets clean version release dpkg
+.PHONY : all prepare all-targets all-libs clean \
+	version compile-tests install release dpkg 
 
 # You may have to change the following sets of macro definitions which will
 # be used throughout the build makefile. These definitions cover the paths
@@ -32,18 +33,7 @@ RANLIB := ppc-amigaos-ranlib
 STRIP := ppc-amigaos-strip
 RANLIB := ppc-amigaos-ranlib
 HOST_CXX := g++
-
-# Check that there is the required cross compiler on the path
-CC_LOC=$(shell which $(CC))
-ifeq ($(CC_LOC),)
-$(error Required cross compiler not found. Expected 'ppc-amigaos-gcc' to be found on the PATH)
-else
-# The only header files we need are the SDK ones
-SDK_INCLUDE ?= $(addsuffix ../ppc-amigaos/SDK/include/,$(dir $(CC_LOC)))
-ifeq ($(realpath $(SDK_INCLUDE)),)
-$(error Required AmigaOS SDK files not found. Expected directory '$(SDK_INCLUDE)' to exist)
-endif
-endif
+SDK_INCLUDE ?= $(abspath $(addsuffix ../ppc-amigaos/SDK/include/,$(dir $(shell which $(word 1,$(CC))))))
 
 # On AmigaOS use native commands
 ifeq ($(UNAME), AmigaOS)
@@ -171,6 +161,16 @@ prepare:
 	-$(MAKEDIR) $(BUILD_DIR)/shared
 	-$(MAKEDIR) $(INSTALL_PREFIX)/lib
 	-$(MAKEDIR) $(INSTALL_PREFIX)/include
+	$(VERBOSE)which $(CC); \
+		if [ $$? -ne 0 ]; \
+		then \
+			echo "Could not locate cross compiler: '$(CC)'" 1>&2; \
+			exit 1; \
+		elif [ ! -d $(SDK_INCLUDE) ]; \
+		then \
+			echo "Could not locate SDK include folder: '$(SDK_INCLUDE)'" 1>&2; \
+			exit 1 ; \
+		fi
 
 ALL_TARGETS = \
 	$(OUTPUT_LIB)/crt0.o \


### PR DESCRIPTION
…nce of the already existing cross compiler and the SDK include path should only happen when it is necessary. The checking has been moved into the 'prepare' rule since that is prequisite for actually building clib4. Before this commit, it would mean that you would have to provide a valid cross-compiler to be available on the PATH even if you just wanted to make 'clean'.

The alternative is to not be so helpful and just let the whole thing fail a little more obscurely.

See also: https://github.com/afxgroup/clib2/issues/157

This is the fix for that.